### PR TITLE
Style should be applied to ::slotted instead of .child

### DIFF
--- a/src/draggable-dom.ts
+++ b/src/draggable-dom.ts
@@ -41,7 +41,7 @@ export class DraggableDOM extends LitElement {
       position: fixed;
       transform: translate(var(--dx), var(--dy));
     }
-    .child {
+    ::slotted(*) {
       --dx: 0px;
       --dy: 0px;
       position: fixed;


### PR DESCRIPTION
This fixes a bug:
On first move the rect and the image jump to the correct position. This is because the initial position isn't displayed correctly.